### PR TITLE
Fix the problem of ngram ratio being rounded down to zero

### DIFF
--- a/nmt_chainer/bleu_computer.py
+++ b/nmt_chainer/bleu_computer.py
@@ -35,7 +35,7 @@ class BleuComputer(object):
                 assert self.ngrams_corrects[n] == 0
                 ratio_n = 1
             else:
-                ratio_n = self.ngrams_corrects[n] / self.ngrams_total[n]
+                ratio_n = float(self.ngrams_corrects[n]) / self.ngrams_total[n]
             res.append("%i/%i[%f%%]"%(self.ngrams_corrects[n], self.ngrams_total[n], 100.0 *ratio_n))
         res.append("size of cand/ref: %i/%i[%f]"%(self.total_length, self.ref_length, float(self.total_length) / self.ref_length))
         return " ".join(res)


### PR DESCRIPTION
In `ratio_n = self.ngrams_corrects[n] / self.ngrams_total[n]`,
ratio_n is zero when `self.ngrams_corrects[n] < self.ngrams_total[n]`, which happens in most cases.
I casted `self.ngrams_corrects[n]` to `float` before doing the division.  
