### PR TITLE
Fix TypeError when getting device number of self.best_loss

### DIFF
--- a/nmt_chainer/training_chainer.py
+++ b/nmt_chainer/training_chainer.py
@@ -248,7 +248,7 @@ class ComputeLossExtension(chainer.training.Extension):
 #                 self.best_loss = cupy.asnumpy(self.best_loss)
         else:
             import cupy
-            if isinstance(self.best_loss, numpy.ndarray) or self.best_loss.device != self.gpu:
+            if isinstance(self.best_loss, numpy.ndarray) or self.best_loss.device.id != self.gpu:
                 with cupy.cuda.Device(self.gpu): self.best_loss = cupy.array(self.best_loss)
                
 class ComputeBleuExtension(chainer.training.Extension):


### PR DESCRIPTION
Fixed `TypeError` that occurred when comparing `cupy.cuda.device.Device` and `int`.